### PR TITLE
(Feat: ActiveMixin, Timezone, User unit tests)

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -99,7 +99,7 @@ AUTH_USER_MODEL = 'users.User'
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'America/Mexico_City'
 
 USE_I18N = True
 

--- a/users/api.py
+++ b/users/api.py
@@ -92,11 +92,9 @@ class CreateUserViewSet(mixins.CreateModelMixin,
             email = data['email']
             password = data['password']
             extra_fields = {
-                'phone': data['phone'],
-                'last_name': data['last_name'],
                 'name': data['name'],
-                'is_staff': data['is_staff'],
-                'is_active': False
+                'last_name': data['last_name'],
+                'is_staff': data['is_staff']
             }
 
             user = User.objects.create_user(

--- a/users/models.py
+++ b/users/models.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import (
 )
 from django.db import models
 
-from utils.models import TimeStampedMixin
+from utils.models import ActiveMixin, TimeStampedMixin
 
 
 class UserManager(BaseUserManager):
@@ -41,15 +41,8 @@ class UserManager(BaseUserManager):
         return self._create_user(email, password, **extra_fields)
 
 
-class User(AbstractBaseUser, PermissionsMixin, TimeStampedMixin):
+class User(AbstractBaseUser, PermissionsMixin, TimeStampedMixin, ActiveMixin):
     """Custom user model to be used accross the app"""
-
-    class Meta:
-        """Define the behavior of Model."""
-
-        verbose_name = 'Usuario'
-        verbose_name_plural = 'Usuarios'
-        ordering = ('email',)
 
     email = models.EmailField(
         max_length=254,
@@ -58,20 +51,15 @@ class User(AbstractBaseUser, PermissionsMixin, TimeStampedMixin):
     )
     name = models.CharField(
         max_length=45,
-        blank=False,
         verbose_name='nombre'
     )
     last_name = models.CharField(
         max_length=45,
-        blank=False,
         verbose_name='apellido',
         default='none'
     )
     is_staff = models.BooleanField(
         default=False
-    )
-    is_active = models.BooleanField(
-        default=True
     )
 
     USERNAME_FIELD = 'email'
@@ -86,3 +74,10 @@ class User(AbstractBaseUser, PermissionsMixin, TimeStampedMixin):
     def get_short_name(self):
         """The user is identified by their email address"""
         return self.email
+
+    class Meta:
+        """Define the behavior of Model."""
+
+        verbose_name = 'Usuario'
+        verbose_name_plural = 'Usuarios'
+        ordering = ('email',)

--- a/users/tests/test_models.py
+++ b/users/tests/test_models.py
@@ -1,8 +1,11 @@
 """ Tests for users of the application."""
 
+from unittest import mock
+
 from django.db import transaction
-from django.db.utils import DataError
+from django.db.utils import DataError, IntegrityError
 from django.test import TestCase
+from django.utils import timezone
 
 from users.models import User
 
@@ -31,3 +34,75 @@ class UserTestCase(TestCase):
             user.last_name = 'x'*46
             with self.assertRaises(DataError):
                 user.save()
+
+    def test_not_nulls(self):
+        """Test not_null fields."""
+        user = self.user
+
+        with transaction.atomic():
+            user.email = None
+            with self.assertRaises(IntegrityError):
+                user.save()
+
+        with transaction.atomic():
+            user.name = None
+            with self.assertRaises(IntegrityError):
+                user.save()
+
+        with transaction.atomic():
+            user.last_name = None
+            with self.assertRaises(IntegrityError):
+                user.save()
+
+        with transaction.atomic():
+            user.last_name = None
+            with self.assertRaises(IntegrityError):
+                user.save()
+
+        with transaction.atomic():
+            user.password = None
+            with self.assertRaises(IntegrityError):
+                user.save()
+
+    def test_nulls(self):
+        """Test null fields."""
+        user = self.user
+
+        user.last_login = None
+        user.save()
+        self.assertEqual(user.last_login, None)
+
+        user.created_date = None
+        user.save()
+        self.assertEqual(user.created_date, None)
+
+    def test_string_representation(self):
+        """Test __str__ and get_short_name methods"""
+        user = self.user
+        self.assertEqual(str(user), user.email)
+        self.assertEqual(user.get_short_name(), user.email)
+
+    def test_created_date(self):
+        """Test created_date field"""
+        user = self.user
+        self.assertEqual(timezone.localdate(), user.created_date.date())
+        self.assertEqual(timezone.localdate(), user.last_modified.date())
+
+    def test_auto_now(self):
+        """Test auto now fields."""
+        user = self.user
+        mocked = timezone.localtime()
+        with mock.patch('django.utils.timezone.now', mock.Mock(
+            return_value=mocked
+        )):
+            user.name = "Test last_modified"
+            user.save()
+            self.assertEqual(user.last_modified, mocked)
+
+    def test_defaults(self):
+        """Test default values."""
+        user = self.user
+        self.assertEqual(user.last_name, 'none')
+        self.assertEqual(user.is_staff, False)
+        self.assertEqual(user.is_superuser, False)
+        self.assertEqual(user.is_active, True)

--- a/utils/models.py
+++ b/utils/models.py
@@ -30,6 +30,17 @@ class TimeStampedMixin(models.Model):
         abstract = True
 
 
+class ActiveMixin(models.Model):
+    is_active = models.BooleanField(
+        default=True
+    )
+
+    class Meta:
+        "abstract because is common information for the models"
+
+        abstract = True
+
+
 class JsonMixin(models.Model):
     data = JSONField(null=True, blank=True)
 


### PR DESCRIPTION
### Type of Changes

- [X] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Deploy to staging (Merge from `dev` to `staging`)
- [ ] Release stable version (Merge from `staging` to `main`)

### Description

- Added ActiveMixin to have is_active field across the app.
- FInished test_models.py for users.
- FInished users/create endpoint so that we can create users for testing without using createsuperuser function.
- Added timezone so can you can use timezone.now() to get UTC datetime or timezone.localtime() to get it in sync to the timezone. 

### Motivation and context

is_active is present in all models to logic deletion.

### Tests
* Test the functionality
* Add screenshots:

* Run tests with `tox`
* Add screenshot:
