### PR TITLE
(Fix: tox.ini, action in users api. Feat: test_api for users module)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,9 +31,12 @@ exclude = migrations, settings.py, .tox
 application-import-names = app
 
 [pytest]
+filterwarnings =
+    ignore::DeprecationWarning
 django_find_project = true
 python_paths = /
 testpaths =
+    app
     utils
     users
     parameters

--- a/users/api.py
+++ b/users/api.py
@@ -60,8 +60,9 @@ class AuthViewSet(mixins.CreateModelMixin,
         if validation_response:
             user = self.get_object(login_serializer.data['email'])
 
-            response_serializer = self.retrieve_serializer_class(
-                user
+            response_serializer = self.get_serializer(
+                user,
+                action='retrieve'
             )
 
             return Response(response_serializer.data)
@@ -83,7 +84,8 @@ class CreateUserViewSet(mixins.CreateModelMixin,
     def create(self, request, *args, **kwargs):
         """Creation of the user depending if is Staff or not"""
         create_serializer = self.get_serializer(
-            data=request.data
+            data=request.data,
+            action='create'
         )
         if create_serializer.is_valid():
             # Revisar webservice de AD
@@ -125,12 +127,12 @@ router.register(
 router.register(
     r'me',
     ProfileViewSet,
-    basename="user_me",
+    basename="me",
     router_class=SingleObjectRouter
 )
 
 router.register(
     r'users/create',
     CreateUserViewSet,
-    basename="user_create",
+    basename="user_create"
 )

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -84,7 +84,6 @@ class AuthResponseSerializer(serializers.ModelSerializer):
         model = User
         fields = [
             'email',
-            'is_staff',
             'token'
         ]
 

--- a/users/tests/test_api.py
+++ b/users/tests/test_api.py
@@ -150,6 +150,27 @@ class MeAPITestCase(APITestCase):
 
         self.url = reverse('me-detail')
 
+    def test_valid(self):
+        """Test valid call using self.user token from /auth."""
+        client = self.client
+        client.credentials(
+            HTTP_AUTHORIZATION=f'Bearer {self.token}'
+        )
+        response = client.get(self.url)
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK
+        )
+        self.assertDictContainsSubset(
+            {"email": self.user.email},
+            response.data
+        )
+        self.assertEqual(
+            {'id', 'email', 'user_permissions', 'groups'},
+            set(response.data.keys())
+        )
+
     def test_invalid(self):
         """Test invalid call using incorrect token."""
         client = self.client

--- a/users/tests/test_api.py
+++ b/users/tests/test_api.py
@@ -1,0 +1,185 @@
+from django.urls import reverse
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from users.models import User
+
+
+class AuthAPITestCase(APITestCase):
+    """Test /auth endpoint."""
+    def setUp(self):
+        self.user = User.objects.create(
+            email='user@test.com',
+            name='Tester',
+        )
+        self.password = 'Tester_123'
+        self.user.set_password(self.password)
+        self.user.save()
+
+        self.url = reverse('auth-list')
+
+    def test_valid(self):
+        """Test valid authentication using self.user credentials."""
+        data = {
+            "email": self.user.email,
+            "password": self.password
+        }
+        response = self.client.post(self.url, data)
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK
+        )
+        self.assertDictContainsSubset(
+            {"email": self.user.email},
+            response.data
+        )
+        self.assertEqual(
+            {'email', 'token'},
+            set(response.data.keys())
+        )
+
+    def test_missing_fields(self):
+        """Test missing fields errors."""
+        data = {}
+        response = self.client.post(self.url, data)
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_400_BAD_REQUEST
+        )
+        self.assertDictContainsSubset(
+            {
+                "email": [
+                    "This field is required."
+                ],
+                "password": [
+                    "This field is required."
+                ]
+            },
+            response.data
+        )
+
+    def test_invalid(self):
+        """Test invalid credentials."""
+        data = {
+            "email": self.user.email.replace('@', '1@'),
+            "password": self.password
+        }
+        response = self.client.post(self.url, data)
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_400_BAD_REQUEST
+        )
+        self.assertDictContainsSubset(
+            {
+                "non_field_errors": [
+                    "credentials are not valid"
+                ]
+            },
+            response.data
+        )
+
+        data = {
+            "email": self.user.email,
+            "password": self.password+'1'
+        }
+        response = self.client.post(self.url, data)
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_400_BAD_REQUEST
+        )
+        self.assertDictContainsSubset(
+            {
+                "non_field_errors": [
+                    "credentials are not valid"
+                ]
+            },
+            response.data
+        )
+
+    def test_not_activated(self):
+        "Test user who is not activated."
+        self.user.is_active = False
+        self.user.save()
+        data = {
+            "email": self.user.email,
+            "password": self.password
+        }
+        response = self.client.post(self.url, data)
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_400_BAD_REQUEST
+        )
+        self.assertDictContainsSubset(
+            {
+                "non_field_errors": [
+                    "The user has not been activated"
+                ]
+            },
+            response.data
+        )
+
+    def tearDown(self):
+        return super().tearDown()
+
+
+class MeAPITestCase(APITestCase):
+    """Test /me endpoint."""
+    def setUp(self):
+        self.user = User.objects.create(
+            email='user@test.com',
+            name='Tester',
+        )
+        self.password = 'Tester_123'
+        self.user.set_password(self.password)
+        self.user.save()
+
+        data = {
+            "email": self.user.email,
+            "password": self.password
+        }
+        response = self.client.post(reverse('auth-list'), data)
+
+        if 'token' in response.data.keys():
+            self.token = response.data['token']
+
+        self.url = reverse('me-detail')
+
+    def test_invalid(self):
+        """Test invalid call using incorrect token."""
+        client = self.client
+        client.credentials(
+            HTTP_AUTHORIZATION='Bearer abc'
+        )
+        response = client.get(self.url)
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_401_UNAUTHORIZED
+        )
+        self.assertDictContainsSubset(
+            {"detail": "Invalid signature."},
+            response.data
+        )
+
+    def test_missing_header(self):
+        """Test missing Authorization header."""
+        client = self.client
+        response = client.get(self.url)
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_401_UNAUTHORIZED
+        )
+        self.assertDictContainsSubset(
+            {"detail": "Authentication credentials were not provided."},
+            response.data
+        )
+
+    def tearDown(self):
+        return super().tearDown()

--- a/users/tests/test_models.py
+++ b/users/tests/test_models.py
@@ -1,5 +1,4 @@
 """ Tests for users of the application."""
-
 from unittest import mock
 
 from django.db import transaction
@@ -85,8 +84,8 @@ class UserTestCase(TestCase):
     def test_created_date(self):
         """Test created_date field"""
         user = self.user
-        self.assertEqual(timezone.localdate(), user.created_date.date())
-        self.assertEqual(timezone.localdate(), user.last_modified.date())
+        self.assertEqual(timezone.now().date(), user.created_date.date())
+        self.assertEqual(timezone.now().date(), user.last_modified.date())
 
     def test_auto_now(self):
         """Test auto now fields."""


### PR DESCRIPTION
### Type of Changes

- [X] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Deploy to staging (Merge from `dev` to `staging`)
- [ ] Release stable version (Merge from `staging` to `main`)

### Description

- `action` was added to some `get_serializer` methods in users api (best practice).
- Corrected bug in `test_models` inside users module that caused a test to fail after certain hour.
- Removed `is_staff` field from `/auth` response (field wasn't being used).
- Added `app` module to tox.ini file so that urls are correctly imported (use of `reverse` method is now enabled in api test cases).
- Added tests cases for endpoints in users module (`/auth` and `/me` because `/users/create`  is a temporal endpoint used only during development due to the use of AD in production).

### Motivation and context

Creation of test_api was vital because the whole team could use it as a template for their own test cases.

### Tests
* Test the functionality
* Add screenshots:
![image](https://user-images.githubusercontent.com/54177784/117604384-dc67fa80-b11a-11eb-9755-7dcf0f7fbc09.png)


* Run tests with `tox`
* Add screenshot:
![image](https://user-images.githubusercontent.com/54177784/117604387-dd992780-b11a-11eb-8dd9-7de23027af0c.png)
